### PR TITLE
Add pytest automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+__tests__
 .vscode
+__pycache__
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ def test():
 With this approach, it's not _always_ possible to validate the input perfectly –
 there are too many options and we want to avoid false positives.
 
+#### Running automated tests
+
+The automated tests make sure that the provided solution code is compatible with
+the test file that's used to validate submissions. The test suite is powered by
+the [`pytest`](https://docs.pytest.org/en/latest/) framework and runnable test
+files are generated automatically in a directory `__tests__` before the test
+session starts. See the [`conftest.py`](conftest.py) for implementation details.
+
+```bash
+# Install requirements
+pip install -r binder/requirements.txt
+# Run the tests (will generate the files automatically)
+python -m pytest __tests__
+```
+
 ### Directory Structure
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -321,10 +321,6 @@ A multiple-choice option.
 
 ## 🛣 Roadmap and todos
 
-- [ ] Add Python CI tests. Not 100% sure how this should be wired up yet – but
-      ideally, `pytest` could somehow assemble the tests just like the
-      `testTemplate` does and then run all solutions against the tests to make
-      sure there are no bugs.
 - [ ] Front-end tests. Also, if someone wants to port this over to TypeScript,
       I'd accept the PR 😛
 - [ ] PDF slides. Since the app is using Reveal.js, this should be possible.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,34 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - 'master'
+
+jobs:
+- job: 'Test'
+  strategy:
+    matrix:
+      Python37Linux:
+        imageName: 'ubuntu-16.04'
+        python.version: '3.7'
+      Python37Windows:
+        imageName: 'vs2017-win2016'
+        python.version: '3.7'
+      Python37Mac:
+        imageName: 'macos-10.13'
+        python.version: '3.7'
+    maxParallel: 4
+  pool:
+    vmImage: $(imageName)
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+
+  - script: pip install -r binder/requirements.txt
+    displayName: 'Install dependencies'
+
+  - script: python -m pytest __tests__
+    displayName: 'Run tests'

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,7 @@
 spacy==2.1.3
 wasabi>=0.2.1,<1.1.0
+srsly>=0.0.5,<1.1.0
+pytest>= 4.4.1,<4.5.0
 
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz#egg=en_core_web_sm==2.1.0
 https://github.com/explosion/spacy-models/releases/download/en_core_web_md-2.1.0/en_core_web_md-2.1.0.tar.gz#egg=en_core_web_md==2.1.0

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+import shutil
+from pathlib import Path
+from wasabi import Printer
+import srsly
+
+TESTS_DIR = "__tests__"
+EXERCISES_DIR = "exercises"
+META_FILE = "meta.json"
+PYTEST_TEMPLATE = "pytestTemplate"
+
+msg = Printer()
+
+
+def format_test(name, template, test, solution):
+    full_code = template.replace("${solution}", solution).replace("${test}", test)
+    # Need to indent the lines to fit it into test function – can probably be less hacky
+    indented = "\n".join(["    " + line for line in full_code.split("\n")])
+    return "def test_{}():\n{}".format(name, indented)
+
+
+def get_source_files():
+    exercises_path = Path(EXERCISES_DIR)
+    if not exercises_path.exists():
+        msg.fail("Can't find exercises directory: {}".format(EXERCISES_DIR), exits=1)
+    for py_file in exercises_path.iterdir():
+        if py_file.name.startswith("test_"):
+            solution_name = "solution_{}".format(py_file.name.split("test_")[1])
+            solution_file = exercises_path / solution_name
+            if not solution_file.exists():
+                msg.warn("Didn't find solution for test: {}".format(py_file.stem))
+            else:
+                yield (py_file, solution_file)
+
+
+def pytest_sessionstart(session):
+    test_dir = Path(TESTS_DIR)
+    if test_dir.exists():
+        shutil.rmtree(str(test_dir))
+        msg.info("Deleted existing test directory {}".format(TESTS_DIR))
+    test_dir.mkdir()
+    msg.good("Created test directory {}".format(TESTS_DIR))
+    meta = srsly.read_json(META_FILE)
+    n_files = 0
+    for test_file, solution_file in get_source_files():
+        with test_file.open("r", encoding="utf8") as f:
+            test_code = f.read()
+        with solution_file.open("r", encoding="utf8") as f:
+            solution_code = f.read()
+        full_code = format_test(
+            test_file.stem, meta[PYTEST_TEMPLATE], test_code, solution_code
+        )
+        test_path = test_dir / test_file.name
+        with test_path.open("w", encoding="utf8") as f:
+            f.write(full_code)
+        n_files += 1
+    msg.good("Created {} files for pytest in {}".format(n_files, TESTS_DIR))

--- a/meta.json
+++ b/meta.json
@@ -7,6 +7,7 @@
     "twitter": "spacy_io",
     "fonts": "IBM+Plex+Mono:500|IBM+Plex+Sans:700|Lato:400,400i,700,700i",
     "testTemplate": "from wasabi import Printer\n__msg__ = Printer()\n__solution__ = \"\"\"${solution}\"\"\"\n\n${solution}\n\n${test}\n\ntry:\n    test()\nexcept AssertionError as e:\n    __msg__.fail(e)",
+    "pytestTemplate": "from wasabi import Printer\n__msg__ = Printer()\n__solution__ = \"\"\"${solution}\"\"\"\n\n${solution}\n\n${test}\ntest()",
     "juniper": {
         "repo": "ines/spacy-course",
         "branch": "binder",


### PR DESCRIPTION
Resolves #10. Can't believe this actually worked 😅

The `conftest.py` does the following _before_ the test session starts and files are collected:

1. Iterate over the files in `/exercises` and find the test files starting with `test_`.
2. Look for matching solution files of the same name.
3. Create a directory `__tests__`.
4. For each test/solution pair, use the `pytestTemplate` in the `meta.json` to combine the file contents into one test, wrapped in a function like `test_01_02_03()`.
5. Write test files to `__tests__`.

This allows running the tests via the following simple command (after installing the requirements):

```bash
python -m pytest __tests__
```