### PR TITLE
Fix typo in Property extensions 1 output

### DIFF
--- a/slides/chapter3_03_extension-attributes.md
+++ b/slides/chapter3_03_extension-attributes.md
@@ -108,7 +108,7 @@ print(doc[3]._.is_color, '-', doc[3].text)
 ```
 
 ```out
-blue - True
+True - blue
 ```
 
 Notes: Property extensions work like properties in Python: they can define a


### PR DESCRIPTION
The order of the strings in the output for the Property extensions 1 example is reversed (`blue - True`). Changed it to `True - blue`.