### PR TITLE
s/character length/token length/

### DIFF
--- a/chapters/chapter3.md
+++ b/chapters/chapter3.md
@@ -150,7 +150,7 @@ languages.
 
 <exercise id="6" title="Simple components">
 
-The example shows a custom component that prints the character length of a
+The example shows a custom component that prints the token length of a
 document. Can you complete it?
 
 - Complete the component function with the `doc`'s length.


### PR DESCRIPTION
It probably would be more correct to say "token length" or "word length" since that's what seems to be expected by the tests and what the solution computes.