### PR TITLE
Fix the description of is_alpha attribute

### DIFF
--- a/slides/chapter1_01_introduction-to-spacy.md
+++ b/slides/chapter1_01_introduction-to-spacy.md
@@ -153,7 +153,7 @@ Notes: Here you can see some of the available token attributes:
 "text" returns the token text.
 
 "is alpha", "is punct" and "like num" return boolean values indicating whether
-the token consists of alphanumeric characters, whether it's punctuation or
+the token consists of alphabetic characters, whether it's punctuation or
 whether it _resembles_ a number. For example, a token "10" – one, zero – or the
 word "ten" – T, E, N.
 

--- a/slides/chapter2_01_data-structures-1.md
+++ b/slides/chapter2_01_data-structures-1.md
@@ -104,7 +104,7 @@ You can get a lexeme by looking up a string or a hash ID in the vocab.
 
 Lexemes expose attributes, just like tokens.
 
-They hold context-independent information about a word, like the text, or whether the the word consists of alphanumeric characters.
+They hold context-independent information about a word, like the text, or whether the the word consists of alphabetic characters.
 
 Lexemes don't have part-of-speech tags, dependencies or entity labels. Those depend on the context.
 


### PR DESCRIPTION
Fix the description of `is_alpha` attribute to point out that it checks for **alphabetic** instead of **alphanumeric** characters, as seen in the [docs](https://spacy.io/api/token#attributes) and in the following example:
```python
print([token.is_alpha for token in nlp("a a9 9")])
```
>[True, False, False]