### PR TITLE
Fix Ch4 Ex3 instructions to match solution

### DIFF
--- a/chapters/en/chapter4.md
+++ b/chapters/en/chapter4.md
@@ -65,7 +65,7 @@ models, so we can create training data to teach a model to recognize them as
 - Write a pattern for two tokens whose lowercase forms match `"iphone"` and
   `"x"`.
 - Write a pattern for two tokens: one token whose lowercase form matches
-  `"iphone"` and a digit using the `"?"` operator.
+  `"iphone"` and a digit using the `"IS_DIGIT"` token attribute.
 
 <codeblock id="04_03">
 


### PR DESCRIPTION
I tried matching as `{"IS_DIGIT": True, "OP": "?"}` but this was not accepted. Also, `{"IS_DIGIT": True}` is the pattern pre-filled for the following exercise. 