### PR TITLE
Change "is" to "looks like" for VERB exercise

### DIFF
--- a/chapters/en/chapter2.md
+++ b/chapters/en/chapter2.md
@@ -184,7 +184,7 @@ nouns that are followed by a verb.
 import spacy
 
 nlp = spacy.load("en_core_web_sm")
-doc = nlp("Berlin is a nice city")
+doc = nlp("Berlin looks like a nice city")
 
 # Get all tokens and part-of-speech tags
 token_texts = [token.text for token in doc]

--- a/chapters/ja/chapter2.md
+++ b/chapters/ja/chapter2.md
@@ -171,7 +171,7 @@ spaCyが普段どのように文字列をトークン化しているかを見る
 import spacy
 
 nlp = spacy.load("en_core_web_sm")
-doc = nlp("Berlin is a nice city")
+doc = nlp("Berlin looks like a nice city")
 
 # 全てのトークンと品詞タグを取得
 token_texts = [token.text for token in doc]

--- a/exercises/en/exc_02_07.py
+++ b/exercises/en/exc_02_07.py
@@ -1,7 +1,7 @@
 import spacy
 
 nlp = spacy.load("en_core_web_sm")
-doc = nlp("Berlin is a nice city")
+doc = nlp("Berlin looks like a nice city")
 
 # Get all tokens and part-of-speech tags
 token_texts = [token.text for token in doc]

--- a/exercises/en/solution_02_07.py
+++ b/exercises/en/solution_02_07.py
@@ -1,7 +1,7 @@
 import spacy
 
 nlp = spacy.load("en_core_web_sm")
-doc = nlp("Berlin is a nice city")
+doc = nlp("Berlin looks like a nice city")
 
 # Iterate over the tokens
 for token in doc:

--- a/exercises/ja/exc_02_07.py
+++ b/exercises/ja/exc_02_07.py
@@ -1,7 +1,7 @@
 import spacy
 
 nlp = spacy.load("en_core_web_sm")
-doc = nlp("Berlin is a nice city")
+doc = nlp("Berlin looks like a nice city")
 
 # すべてのトークンの文字列と品詞タグを取得
 token_texts = [token.text for token in doc]

--- a/exercises/ja/solution_02_07.py
+++ b/exercises/ja/solution_02_07.py
@@ -1,7 +1,7 @@
 import spacy
 
 nlp = spacy.load("en_core_web_sm")
-doc = nlp("Berlin is a nice city")
+doc = nlp("Berlin looks like a nice city")
 
 # すべてのトークンの文字列と品詞タグを取得
 for token in doc:


### PR DESCRIPTION
The treatment of "is" is inconsistent across spacy versions, so modify the example to use a less ambiguous / more consistently tagged verb.