### PR TITLE
explicitely add string to vocab

### DIFF
--- a/chapters/de/slides/chapter2_01_data-structures-1.md
+++ b/chapters/de/slides/chapter2_01_data-structures-1.md
@@ -22,6 +22,7 @@ spaCy mit Strings umgeht.
 - String-Speicher: **Zuordnungstabelle** in beide Richtungen
 
 ```python
+nlp.vocab.strings.add("Kaffee")
 kaffee_hash = nlp.vocab.strings["Kaffee"]
 kaffee_string = nlp.vocab.strings[kaffee_hash]
 ```

--- a/chapters/en/slides/chapter2_01_data-structures-1.md
+++ b/chapters/en/slides/chapter2_01_data-structures-1.md
@@ -21,6 +21,7 @@ with strings.
 - String store: **lookup table** in both directions
 
 ```python
+nlp.vocab.strings.add("coffee")
 coffee_hash = nlp.vocab.strings["coffee"]
 coffee_string = nlp.vocab.strings[coffee_hash]
 ```

--- a/chapters/es/slides/chapter2_01_data-structures-1.md
+++ b/chapters/es/slides/chapter2_01_data-structures-1.md
@@ -21,6 +21,7 @@ maneja los strings.
 - String store: un **lookup table** en ambas direcciones
 
 ```python
+nlp.vocab.strings.add("café")
 cafe_hash = nlp.vocab.strings["café"]
 cafe_string = nlp.vocab.strings[cafe_hash]
 ```

--- a/chapters/fr/slides/chapter2_01_data-structures-1.md
+++ b/chapters/fr/slides/chapter2_01_data-structures-1.md
@@ -23,6 +23,7 @@ comment spaCy gère les chaines de caractères.
 - String store : **table de consultation** dans les deux sens
 
 ```python
+nlp.vocab.strings.add("souvent")
 souvent_hash = nlp.vocab.strings["souvent"]
 souvent_string = nlp.vocab.strings[souvent_hash]
 ```

--- a/chapters/ja/slides/chapter2_01_data-structures-1.md
+++ b/chapters/ja/slides/chapter2_01_data-structures-1.md
@@ -17,6 +17,7 @@ Notes: Welcome back！さて、いくつかのspaCyのオブジェクトを扱�
 - String store: 双方向ルックアップテーブル
 
 ```python
+nlp.vocab.strings.add("コーヒー")
 coffee_hash = nlp.vocab.strings["コーヒー"]
 coffee_string = nlp.vocab.strings[coffee_hash]
 ```

--- a/chapters/pt/slides/chapter2_01_data-structures-1.md
+++ b/chapters/pt/slides/chapter2_01_data-structures-1.md
@@ -19,6 +19,7 @@ Nesta lição, vamos dar uma olhada no vocabulário compartilhado (Vocab) e como
 - Armazenamento de Strings: **tabelas de consultas** que funcionam em ambos sentidos
 
 ```python
+nlp.vocab.strings.add("coffee")
 coffee_hash = nlp.vocab.strings["coffee"]
 coffee_string = nlp.vocab.strings[coffee_hash]
 ```

--- a/chapters/zh/slides/chapter2_01_data-structures-1.md
+++ b/chapters/zh/slides/chapter2_01_data-structures-1.md
@@ -19,6 +19,7 @@ Notes: 欢迎回来！现在你已经有一些spaCy实例的实战经验了，
 - 字符串库：双向的**查询表**
 
 ```python
+nlp.vocab.strings.add("咖啡")
 coffee_hash = nlp.vocab.strings["咖啡"]
 coffee_string = nlp.vocab.strings[coffee_hash]
 ```


### PR DESCRIPTION
To avoid confusion when a string is not yet in the vocab, add it first explicitely.

We've gotten some questions/confusion around this on the spaCy issue tracker, cf https://github.com/explosion/spaCy/issues/7619 and https://github.com/explosion/spaCy/issues/1985#issuecomment-650536370, so it might be good to make this more explicit in the course slides.