### PR TITLE
Fix JA test for 3.2

### DIFF
--- a/exercises/ja/test_03_11.py
+++ b/exercises/ja/test_03_11.py
@@ -6,8 +6,9 @@ def test():
         "getter=get_wikipedia_url" in __solution__
     ), "get_wikipedia_urlをゲッターとして登録しましたか？"
     assert "(ent.text, ent._.wikipedia_url)" in __solution__, "カスタム属性にアクセスしましたか？"
+    # XXX The index here is brittle with model updates
     assert (
-        doc.ents[-1]._.wikipedia_url
+        doc.ents[-2]._.wikipedia_url
         == "https://ja.wikipedia.org/wiki/デヴィッド・ボウイ"
     ), "ゲッター属性の値が誤っているようです"
 


### PR DESCRIPTION
One test was failing because the 3.2 models introduced another entity. I
adjusted the entity index but it might be better to check the text?
This'll work for now.

The new entity is 現代文化 ("modern culture") as a NORP, which is kind
of weird.