### PR TITLE
Full revision of `es` course v3 based on feedback

### DIFF
--- a/chapters/es/chapter3.md
+++ b/chapters/es/chapter3.md
@@ -411,7 +411,7 @@ keys `"author"` y `"book"`.
 
 <exercise id="16" title="Procesamiento selectivo">
 
-En este ejercicio usarás los métodos `nlp.make_doc` y `nlp.disable_pipes` para
+En este ejercicio usarás los métodos `nlp.make_doc` y `nlp.select_pipes` para
 correr unicamente los componentes seleccionados cuando se procesa un texto.
 
 ### Parte 1
@@ -428,14 +428,15 @@ igual que el objeto `nlp`.
 
 ### Parte 2
 
-- Deshabilita el parser usando el método `nlp.disable_pipes`.
+- Deshabilita el parser usando el método `nlp.select_pipes`.
 - Procesa el texto e imprime en pantalla todas las entidades en el `doc`.
 
 <codeblock id="03_16_02">
 
-El método `nlp.disable_pipes` recibe un número variable de argumentos: los
+El método `nlp.select_pipes` recibe un número variable de argumentos: los
 nombres en string de los componentes del pipeline que serán deshabilitados. Por
-ejemplo, `nlp.disable_pipes("ner")` deshabilitará el named entity recognizer.
+ejemplo, `nlp.select_pipes(disable="ner")` deshabilitará el named entity 
+recognizer.
 
 </codeblock>
 

--- a/chapters/es/chapter4.md
+++ b/chapters/es/chapter4.md
@@ -108,8 +108,9 @@ a un archivo `.spacy`. El código del ejemplo anterior está disponible.
 
 <exercise id="6" title="El config de entrenamiento">
 
-The `config.cfg` file is the "single source of truth" for training a pipeline
-with spaCy. Which of the following is **not true** about the config?
+El archivo `config.cfg` es la única "fuente de verdad" para entrenar un
+pipeline con spaCy. ¿Cuál de las siguientes respuestas acerca del archivo
+config es **incorrecta**?
 
 <choice>
 
@@ -188,17 +189,17 @@ inspeccionarlo.
 como el corpus que creamos para entrenar un named entity recognizer!
 
 El comando [`train`](https://spacy.io/api/cli#train) te permite entrenar un
-modelo utilizando un archivo config file. Un archivo `config_gadget.cfg` ya está
-listo en el directorio `exercises/en`, así como el archivo `train_gadget.spacy`
+modelo utilizando un archivo "config". Un archivo `config_gadget.cfg` ya está
+listo en el directorio `exercises/es`, así como el archivo `train_gadget.spacy`
 que contiene ejemplos de entrenamiento y un archivo llamado `dev_gadget.spacy`
 que contiene los datos de evaluación. Debido a que estamos ejecutando el comando
-en un entorno de Jupyterm en este curso, usaremos el prefijo `!`. Si planeas
+en un entorno de Jupyter en este curso, usaremos el prefijo `!`. Si planeas
 correr el comando en tu terminal local, puedes omitir este prefijo.
 
-- Invoca el comando `train` con el archivo `exercises/en/config_gadget.cfg`.
+- Invoca el comando `train` con el archivo `exercises/es/config_gadget.cfg`.
 - Guarda el pipeline entrenado en el directorio de nombre `output`.
-- Pasa también las rutas de archivo `exercises/en/train_gadget.spacy` y
-  `exercises/en/dev_gadget.spacy`.
+- Pasa también las rutas de archivo `exercises/es/train_gadget.spacy` y
+  `exercises/es/dev_gadget.spacy`.
 
 <codeblock id="04_08">
 

--- a/chapters/es/slides/chapter3_02_custom-pipeline-components.md
+++ b/chapters/es/slides/chapter3_02_custom-pipeline-components.md
@@ -59,8 +59,13 @@ Notes: Fundamentalmente, un componente del pipeline es una función o un
 que toma a un doc, lo modifica y lo devuelve para que pueda ser procesado por
 el próximo componente en el pipeline.
 
-Los componentes pueden ser añadidos al pipeline usando el método `nlp.add_pipe`.
-Éste toma al menos un argumento: la función del componente.
+Para decirle a spaCy en dónde encontrar tu componente personalizado y cómo debe
+ser llamado, lo puedes decorar utilizando `@Language.component`. Solamente
+añádelo a la línea inmediatamente anterior a la definición de la función.
+
+Una vez que un componente está registrado, puede ser añadido al pipeline con el
+método `nlp.add_pipe`. Este método toma al menos un argumento: el nombre del 
+componente.
 
 ---
 
@@ -128,7 +133,7 @@ Pipeline: ['custom_component', 'tok2vec', 'morphologizer', 'parser', 'attribute_
 
 Notes: Aquí tenemos un ejemplo de un componente simple del pipeline.
 
-Comenzamos con el modelo pequeño de español.
+Comenzamos con el pipeline más pequeño para español.
 
 Luego definimos el componente - una función que toma un objeto `Doc` y luego lo
 devuelve.
@@ -140,8 +145,11 @@ por el pipeline.
 componente en el pipeline! El doc creado por el tokenizer pasa por todos los
 componentes, así que es importante que todos devuelvan el doc modificado.
 
-Ahora podemos añadir el componente al pipeline. Vamos a añadirlo en el primer
-lugar, justo después del tokenizer. Lo hacemos definiendo `first=True`.
+Para informarle a spaCy acerca del nuevo componente, lo registramos utilizando
+el decorador `@Language.component` y lo llamamos "custom_component".
+
+Ahora podemos añadir el componente al pipeline. Vamos a añadirlo al inicio, 
+justo después del tokenizer. Lo hacemos definiendo `first=True`.
 
 Cuando imprimimos en pantalla los nombres de los componentes el nuevo aparece
 al principio. Esto significa que será aplicado cuando procesemos un doc.

--- a/chapters/es/slides/chapter3_04_scaling-performance.md
+++ b/chapters/es/slides/chapter3_04_scaling-performance.md
@@ -150,7 +150,7 @@ en un doc antes de invocar los componentes del pipeline.
 
 ```python
 # Desactiva el tagger y el parser
-with nlp.disable_pipes("tagger", "parser"):
+with nlp.select_pipes(disable=["tagger", "parser"])
     # Procesa el texto e imprime las entidades en pantalla
     doc = nlp(text)
     print(doc.ents)
@@ -162,10 +162,10 @@ with nlp.disable_pipes("tagger", "parser"):
 Notes: spaCy también te permite deshabilitar temporalmente componentes del
 pipeline usando el <abbr title='Que puede ser usado dentro de un bloque de código "with".'>context manager</abbr> `nlp.disable_pipes`.
 
-Toma un número de argumentos variable, los nombres en string de los componentes
-a ser deshabilitados. Por ejemplo, si solo quieres usar el entity recognizer
-para procesar un documento, puedes deshabilitar temporalmente el tagger y el
-parser.
+Toma los argumentos variables `enable` o `disable` que pueden definir una 
+lista de componentes para desabilitarlos. Por ejemplo, si solo quieres usar el 
+entity recognizer para procesar un documento, puedes deshabilitar temporalmente 
+el tagger y el parser.
 
 Después del bloque `with`, los componentes del pipeline deshabilitados se
 restauran automáticamente.

--- a/chapters/es/slides/chapter4_01_training-updating-models.md
+++ b/chapters/es/slides/chapter4_01_training-updating-models.md
@@ -131,7 +131,7 @@ Debido a que el entity recognizer predice entidades _en contexto_ también
 necesita ser entrenado en las entidades _y_ su contexto.
 
 La forma más fácil de hacer esto es mostrarle al modelo un texto y una lista de
-posiciones de caracteres. Por ejemplo, "adidas ZX" es ropa, comienza en el token
+_spans de entidades_. Por ejemplo, "adidas ZX" es ropa, comienza en el token
 2 y termina en el token 4.
 
 También es muy importante que el modelo aprenda palabras que _no son_ entidades.

--- a/exercises/es/test_03_16_02.py
+++ b/exercises/es/test_03_16_02.py
@@ -1,7 +1,7 @@
 def test():
     assert (
         'with nlp.select_pipes(disable=["parser"])' in __solution__
-    ), "¿Estás usando nlp.disable_pipes con los componentes correctos?"
+    ), "¿Estás usando nlp.select_pipes con los componentes correctos?"
 
     __msg__.good(
         "¡Perfecto! Ahora que has practicado los consejos y trucos de rendimiento, "


### PR DESCRIPTION
## Feedback:

**Chapter 3**

*3.4 Componentes personalizados del pipeline
file: `chapter3_02_custom-pipeline-components.md`*

- [X] side note of slide `Anatomía de un componente (1)` is not in line with English v3
- [X] side note of slide `Ejemplo: un componente simple (1)` is not in line with English v3

*3.13 Aumentando la escala y el desempeño
file: `chapter3_04_scaling-performance.md`*

- [X] the slide `Desactivando los componentes del pipeline` is not in line with English v3
  (text, code and site notes are not updated to `nlp.select_pipes` method and syntax
  and still refer to previous version with `nlp.disable_pipes`)

*3.16 Procesamiento selectivo
file: `chapter3.md` (section exercise 16)*

- [X] part 2 of exercise instructions is not updated with use of `nlp.select_pipes` 
  (still refer to `nlp.disable_pipes`)

*Test 03_16_02
file: `test_03_16_02.py`*

- [X] The error message string on line 4 is not updated to require use of `nlp.select_pipes`

**Chapter 4**

*4.1 Entrenando y actualizando modelos
file: `chapter4_01_training-updating-models.md`*

- [X] in the side note of slide, the first sentence of the 5th paragraph still refers to
  `una lista de posiciones de caracteres` (should now be `Entity spans`).

*4.6 El config de entrenamiento
file: `chapter4.md` (section exercise 6)*

- [X] the question of the quizz is in English instead of Spanish

*Cómo utilizar el CLI de entrenamiento
file: `chapter4.md` (section exercise 8)*

- [X] in the instruction section of the exercices, the 4 given paths all refer to
  the `en` directory